### PR TITLE
add connector_all_accounts_unsupported code

### DIFF
--- a/locales/de-de.yml
+++ b/locales/de-de.yml
@@ -1,6 +1,7 @@
 errors:
   connector_access_already_exists:   Dieser Bankzugang existiert bereits
   connector_account_does_not_support_account_balance_request: Der Bankzugang enthält momentan keine unterstützten Bankkonten
+  connector_all_accounts_unsupported: Der Bankzugang enthält momentan keine unterstützten Bankkonten
   connector_cant_be_empty:           Alle Formularfelder werden benötigt
   connector_could_not_connect:       Keine Antwort der Bank erhalten. Bitte versuchen Sie es später noch einmal oder kontaktieren Sie den Kundendienst, falls das Problem weiter besteht
   connector_field_reset:             Die Authentifizierung mit PIN war nicht erfolgreich. Bitte geben Sie Ihre Online-Banking PIN erneut ein

--- a/locales/en-gb.yml
+++ b/locales/en-gb.yml
@@ -1,6 +1,7 @@
 errors:
   connector_access_already_exists:   Bank access already added
   connector_account_does_not_support_account_balance_request: The bank access you are trying to add has no supported bank accounts at this time
+  connector_all_accounts_unsupported: The bank access you are trying to add has no supported bank accounts at this time
   connector_cant_be_empty:           Please complete all fields in the form
   connector_could_not_connect:       Your bank is not responding at the moment. Please try again later or contact support if the problem persists
   connector_field_reset:             The PIN authentication was unfortunately incorrect. Please enter your online banking PIN again

--- a/src/errorcodes.txt
+++ b/src/errorcodes.txt
@@ -1,5 +1,6 @@
 connector_access_already_exists
 connector_account_does_not_support_account_balance_request
+connector_all_accounts_unsupported
 connector_cant_be_empty
 connector_could_not_connect
 connector_field_reset


### PR DESCRIPTION
I thought about reusing the `connector_account_does_not_support_account_balance_request `, but the code value itself it's confusing outside of the numbrs, so decided to continue with the new one with the same message translation.